### PR TITLE
Separate dependencies into a layer to reduce lambda bundle size

### DIFF
--- a/.github/workflows/backend-pipeline.yaml
+++ b/.github/workflows/backend-pipeline.yaml
@@ -86,9 +86,11 @@ jobs:
         with:
           use-installer: true
       - uses: astral-sh/setup-uv@v7
-      - run: uv export --frozen --no-dev --no-editable -o requirements.txt
-        working-directory: backend/backend
-      - run: sam build --config-env ci --template ${SAM_TEMPLATE} --use-container
+      - run: | 
+          mkdir -p dep_layer
+          uv export --project backend --frozen --no-dev --no-editable -o dep_layer/requirements.txt
+      - name: Build resources
+        run: sam build --config-env ci --template ${SAM_TEMPLATE} --use-container
 
       - name: Assume the testing pipeline user role
         uses: aws-actions/configure-aws-credentials@v4
@@ -131,9 +133,9 @@ jobs:
         with:
           use-installer: true
       - uses: astral-sh/setup-uv@v7
-      - run: uv export --frozen --no-dev --no-editable -o requirements.txt
-        working-directory: backend/backend
-
+      - run: |
+          mkdir -p dep_layer
+          uv export --project backend --frozen --no-dev --no-editable -o dep_layer/requirements.txt
       - name: Build resources
         run: sam build --config-env ci --template ${SAM_TEMPLATE} --use-container
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,2 @@
-sam-app/
 .aws-sam
+dep_layer

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -10,6 +10,15 @@ Globals:
 
 
 Resources:
+  DependencyLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: dep_layer/
+      CompatibleRuntimes:
+        - python3.12
+    Metadata:
+      BuildMethod: python3.12
+
   HandlerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -18,6 +27,8 @@ Resources:
       Runtime: python3.12
       Architectures:
         - x86_64
+      Layers:
+        - !Ref DependencyLayer
       Events:
         RootPath:
           Type: Api


### PR DESCRIPTION
## Purpose

Putting the dependencies in their own layer prevents them from being deployed every time application code changes. This reduces S3 usage and slightly improves deploy times.

This PR is currently based on #18 to show it still deploys and starts up ok.

## Changes

Adds a lambda layer to the CF stack and makes the handler function use it. Some small changes in the deploy pipeline to put the dependency manifest in the right location for SAM to find it.

## Verification

- [x] CI workflow passes
- [x] Coverage ≥ 70 %
- [x] Reviewer assigned
